### PR TITLE
draft: Adding in a basic implementation of an in memory draft coordinator and an interface for later implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 all:
+	go fmt ./...
+	go build ./...
 	go build -o bin/cuddly-quack
 
 clean:

--- a/app/index.go
+++ b/app/index.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 )
 
-type IndexHandler struct {}
+type IndexHandler struct{}
 
 func (i *IndexHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	rw.Write([]byte("hello world"))	
+	rw.Write([]byte("hello world"))
 }

--- a/draft/coordinator.go
+++ b/draft/coordinator.go
@@ -2,6 +2,7 @@ package draft
 
 // Coordinator is an interface which
 // keeps track of active draft rooms and who is authenticated to join them.
-type Coordinator interface{} {
-	DraftRoom(string id, string userID) (*Room, error)
+type Coordinator interface {
+	GetDraftRoom(id string, userID string) (*Room, error)
+	CreateDraftRoom(id string) (*Room, error)
 }

--- a/draft/coordinator.go
+++ b/draft/coordinator.go
@@ -1,0 +1,7 @@
+package draft
+
+// Coordinator is an interface which
+// keeps track of active draft rooms and who is authenticated to join them.
+type Coordinator interface{} {
+	DraftRoom(string id, string userID) (*Room, error)
+}

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -22,7 +22,6 @@ func NewInMemoryCoordinator() (*InMemoryCoordinator) {
 }
 
 func(i *InMemoryCoordinator) DraftRoom(id string, userID string) (*draft.Room, error) {
-	// TODO Implement
 	room, ok := i.DraftRooms(id)
 	if !ok {
 		return nil, errors.New("Couldn't find draft room")
@@ -31,6 +30,7 @@ func(i *InMemoryCoordinator) DraftRoom(id string, userID string) (*draft.Room, e
 	return room, nil
 }
 
-func (i *InMemoryCoordinator) CreateDraftRoom(id string) (error) {
+func (i *InMemoryCoordinator) CreateDraftRoom(id string) (*draft.Room, error) {
 	i[id] = &draft.Room{}
+	return i[id], nil
 }

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -2,7 +2,7 @@ package coordinators
 
 import (
 	"errors"
-	
+
 	"github.com/flp/cuddly-quack/draft"
 )
 
@@ -15,22 +15,22 @@ type InMemoryCoordinator struct {
 	DraftRooms map[string]*draft.Room
 }
 
-func NewInMemoryCoordinator() (*InMemoryCoordinator) {
+func NewInMemoryCoordinator() *InMemoryCoordinator {
 	return &InMemoryCoordinator{
 		DraftRooms: make(map[string]*draft.Room),
 	}
 }
 
-func(i *InMemoryCoordinator) DraftRoom(id string, userID string) (*draft.Room, error) {
-	room, ok := i.DraftRooms(id)
+func (i *InMemoryCoordinator) GetDraftRoom(id string, userID string) (*draft.Room, error) {
+	room, ok := i.DraftRooms[id]
 	if !ok {
 		return nil, errors.New("Couldn't find draft room")
 	}
-	
+
 	return room, nil
 }
 
 func (i *InMemoryCoordinator) CreateDraftRoom(id string) (*draft.Room, error) {
-	i[id] = &draft.Room{}
-	return i[id], nil
+	i.DraftRooms[id] = &draft.Room{}
+	return i.DraftRooms[id], nil
 }

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -1,0 +1,36 @@
+package coordinators
+
+import (
+	"errors"
+	
+	"github.com/flp/cuddly-quack/draft"
+)
+
+// InMemoryCoordinator is a very basic implementation
+// of a draft room coordinator.  It will house draft rooms
+// in RAM.  Note that if the node dies, so will all the current draft rooms.
+// This is intended to be a preliminary implementation for testing purposes.
+// In the future, we'll want more persistent draft rooms.
+type InMemoryCoordinator struct {
+	DraftRooms map[string]*draft.Room
+}
+
+func NewInMemoryCoordinator() (*InMemoryCoordinator) {
+	return &InMemoryCoordinator{
+		DraftRooms: make(map[string]*draft.Room),
+	}
+}
+
+func(i *InMemoryCoordinator) DraftRoom(id string, userID string) (*draft.Room, error) {
+	// TODO Implement
+	room, ok := i.DraftRooms(id)
+	if !ok {
+		return nil, errors.New("Couldn't find draft room")
+	}
+	
+	return room, nil
+}
+
+func (i *InMemoryCoordinator) CreateDraftRoom(id string) (error) {
+	i[id] = &draft.Room{}
+}

--- a/draft/room.go
+++ b/draft/room.go
@@ -1,0 +1,16 @@
+package draft
+
+type Room struct {
+	// TODO Implement
+	// - name
+	// - authentication?
+	//   - basic: password
+	//   - invite only
+	//   - etc
+	// - list of authenticated players
+	// - state & state machine:
+	//   - open
+	//   - started
+	//   - playing
+	//   - closed
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"net/http"
 	"log"
+	"net/http"
 
 	"github.com/flp/cuddly-quack/app"
 )
 
 func main() {
-	http.Handle("/", &app.IndexHandler{})	
+	http.Handle("/", &app.IndexHandler{})
 	err := http.ListenAndServe(":8000", nil)
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)


### PR DESCRIPTION
This PR introduces a basic in memory draft room coordinator.  Obviously, this isn't the most sound approach, as if the node goes down, it will loose all track of all the current drafts, but it gets us up and running without needing to connect to a DB.

To address this issue, I've created an interface in `coordinator.go`, which describes the behavior we will want to provide for a DB backed coordination system in the future.
