### PR TITLE
Issue/create draft room

### DIFF
--- a/app/index.go
+++ b/app/index.go
@@ -1,11 +1,17 @@
 package app
 
 import (
+	"fmt"
 	"net/http"
+
+	"github.com/flp/cuddly-quack/draft/coordinators"
 )
 
 type IndexHandler struct{}
 
 func (i *IndexHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	rw.Write([]byte("hello world"))
+	// TODO settle on some kind of templating engine.
+	for _, room := range coordinators.DefaultInMemoryCoordinator.DraftRooms {
+		rw.Write([]byte(fmt.Sprintf("%v\n", room)))
+	}
 }

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	"github.com/flp/cuddly-quack/draft"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 // InMemoryCoordinator is a very basic implementation
@@ -16,6 +18,8 @@ type InMemoryCoordinator struct {
 	Lock       sync.Mutex
 	DraftRooms map[string]*draft.Room
 }
+
+var DefaultInMemoryCoordinator *InMemoryCoordinator
 
 func NewInMemoryCoordinator() *InMemoryCoordinator {
 	return &InMemoryCoordinator{
@@ -47,4 +51,8 @@ func (i *InMemoryCoordinator) CreateDraftRoom(id string) (*draft.Room, error) {
 	i.Lock.Unlock()
 
 	return room, nil
+}
+
+func init() {
+	DefaultInMemoryCoordinator = NewInMemoryCoordinator()
 }

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -2,6 +2,7 @@ package coordinators
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/flp/cuddly-quack/draft"
 )
@@ -12,6 +13,7 @@ import (
 // This is intended to be a preliminary implementation for testing purposes.
 // In the future, we'll want more persistent draft rooms.
 type InMemoryCoordinator struct {
+	Lock       sync.Mutex
 	DraftRooms map[string]*draft.Room
 }
 
@@ -22,7 +24,13 @@ func NewInMemoryCoordinator() *InMemoryCoordinator {
 }
 
 func (i *InMemoryCoordinator) GetDraftRoom(id string, userID string) (*draft.Room, error) {
-	room, ok := i.DraftRooms[id]
+	var room *draft.Room
+	var ok bool
+
+	i.Lock.Lock()
+	room, ok = i.DraftRooms[id]
+	i.Lock.Unlock()
+
 	if !ok {
 		return nil, errors.New("Couldn't find draft room")
 	}
@@ -31,6 +39,12 @@ func (i *InMemoryCoordinator) GetDraftRoom(id string, userID string) (*draft.Roo
 }
 
 func (i *InMemoryCoordinator) CreateDraftRoom(id string) (*draft.Room, error) {
+	var room *draft.Room
+
+	i.Lock.Lock()
 	i.DraftRooms[id] = &draft.Room{}
-	return i.DraftRooms[id], nil
+	room = i.DraftRooms[id]
+	i.Lock.Unlock()
+
+	return room, nil
 }

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -42,12 +42,18 @@ func (i *InMemoryCoordinator) GetDraftRoom(id string, userID string) (*draft.Roo
 	return room, nil
 }
 
-func (i *InMemoryCoordinator) CreateDraftRoom(id string) (*draft.Room, error) {
+func (i *InMemoryCoordinator) CreateDraftRoom(name string) (*draft.Room, error) {
 	var room *draft.Room
 
 	i.Lock.Lock()
-	i.DraftRooms[id] = &draft.Room{}
-	room = i.DraftRooms[id]
+
+	id := uuid.NewV4()
+	room = &draft.Room{
+		Name: name,
+		UUID: id,
+	}
+
+	i.DraftRooms[id.String()] = room
 	i.Lock.Unlock()
 
 	return room, nil

--- a/draft/room.go
+++ b/draft/room.go
@@ -1,8 +1,13 @@
 package draft
 
+import (
+	uuid "github.com/satori/go.uuid"
+)
+
 type Room struct {
 	// TODO Implement
-	// - name
+	Name string
+	UUID uuid.UUID
 	// - authentication?
 	//   - basic: password
 	//   - invite only

--- a/main.go
+++ b/main.go
@@ -5,9 +5,12 @@ import (
 	"net/http"
 
 	"github.com/flp/cuddly-quack/app"
+	"github.com/flp/cuddly-quack/draft/coordinators"
 )
 
 func main() {
+	coordinators.DefaultInMemoryCoordinator.CreateDraftRoom("test")
+
 	http.Handle("/", &app.IndexHandler{})
 	err := http.ListenAndServe(":8000", nil)
 	if err != nil {


### PR DESCRIPTION
This PR introduces a concurrent locking mechanism and an example of creating a draft room on boot.  When you load up the application and visit `http://localhost:8000`, you'll see the following output:

```
&{test <uuidv4>}
```

Upon refresh, you'll see that the draft room exists, and persists across requests.  
