### PR TITLE
Issue/create draft

### DIFF
--- a/app/create.go
+++ b/app/create.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/flp/cuddly-quack/draft/coordinators"
+	"github.com/flp/cuddly-quack/wire"
+)
+
+type CreateDraftHandler struct{}
+
+func (c *CreateDraftHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		// 400 bad request
+	}
+
+	var msg *wire.CreateDraftRequest
+	err = json.Unmarshal(data, msg)
+	if err != nil {
+		// 400 bad request
+	}
+
+	coordinators.DefaultInMemoryCoordinator.CreateDraftRoom(msg)
+	// 201 Created
+}

--- a/app/create.go
+++ b/app/create.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -16,13 +17,17 @@ func (c *CreateDraftHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		// TODO Define JSON error bodies
 		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Printf("NO BODY")
+		return
 	}
 
-	var msg *wire.CreateDraftRequest
+	msg := &wire.CreateDraftRequest{}
 	err = json.Unmarshal(data, msg)
 	if err != nil {
 		// TODO Define JSON error bodies
 		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Printf("err: %v", err)
+		return
 	}
 
 	coordinators.DefaultInMemoryCoordinator.CreateDraftRoom(msg)

--- a/app/create.go
+++ b/app/create.go
@@ -14,15 +14,17 @@ type CreateDraftHandler struct{}
 func (c *CreateDraftHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		// 400 bad request
+		// TODO Define JSON error bodies
+		rw.WriteHeader(http.StatusBadRequest)
 	}
 
 	var msg *wire.CreateDraftRequest
 	err = json.Unmarshal(data, msg)
 	if err != nil {
-		// 400 bad request
+		// TODO Define JSON error bodies
+		rw.WriteHeader(http.StatusBadRequest)
 	}
 
 	coordinators.DefaultInMemoryCoordinator.CreateDraftRoom(msg)
-	// 201 Created
+	rw.WriteHeader(http.StatusCreated)
 }

--- a/app/create.go
+++ b/app/create.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -17,7 +16,6 @@ func (c *CreateDraftHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		// TODO Define JSON error bodies
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Printf("NO BODY")
 		return
 	}
 
@@ -26,7 +24,6 @@ func (c *CreateDraftHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		// TODO Define JSON error bodies
 		rw.WriteHeader(http.StatusBadRequest)
-		fmt.Printf("err: %v", err)
 		return
 	}
 

--- a/draft/coordinator.go
+++ b/draft/coordinator.go
@@ -1,5 +1,9 @@
 package draft
 
+import (
+	"github.com/flp/cuddly-quack/wire"
+)
+
 // Coordinator is an interface which
 // keeps track of active draft rooms and who is authenticated to join them.
 type Coordinator interface {

--- a/draft/coordinators/in_memory_coordinator.go
+++ b/draft/coordinators/in_memory_coordinator.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/flp/cuddly-quack/draft"
+	"github.com/flp/cuddly-quack/wire"
 
 	uuid "github.com/satori/go.uuid"
 )
@@ -42,14 +43,14 @@ func (i *InMemoryCoordinator) GetDraftRoom(id string) (*draft.Room, error) {
 	return room, nil
 }
 
-func (i *InMemoryCoordinator) CreateDraftRoom(name string) (*draft.Room, error) {
+func (i *InMemoryCoordinator) CreateDraftRoom(req *wire.CreateDraftRequest) (*draft.Room, error) {
 	var room *draft.Room
 
 	i.Lock.Lock()
 
 	id := uuid.NewV4()
 	room = &draft.Room{
-		Name: name,
+		Name: req.Name,
 		UUID: id,
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 
 	http.Handle("/", &app.IndexHandler{})
 	http.Handle("/drafts/{id}", &app.ShowHandler{})
+	http.Handle("/drafts", &app.CreateDraftHandler{})
 	err := http.ListenAndServe(":8000", nil)
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)

--- a/main.go
+++ b/main.go
@@ -10,10 +10,14 @@ import (
 	"github.com/flp/cuddly-quack/app"
 	"github.com/flp/cuddly-quack/draft/coordinators"
 	"github.com/flp/cuddly-quack/mtg"
+	"github.com/flp/cuddly-quack/wire"
 )
 
 func main() {
-	coordinators.DefaultInMemoryCoordinator.CreateDraftRoom("test")
+	coordinators.DefaultInMemoryCoordinator.CreateDraftRoom(&wire.CreateDraftRequest{
+		Name: "test",
+		Set:  "BFZ",
+	})
 
 	// Seed the rng
 	rand.Seed(time.Now().UnixNano())

--- a/wire/create_draft_request.go
+++ b/wire/create_draft_request.go
@@ -1,0 +1,6 @@
+package wire
+
+type CreateDraftRequest struct {
+	Name string `json:"name"`
+	Set  string `json:"string"`
+}


### PR DESCRIPTION
Creates draft rooms and persists them!

Here's the test:

```
kellydunn in ~/gopath/src/github.com/flp/cuddly-quack on issue/create-draft*
$ curl -X POST http://localhost:8000/drafts -d '{"name":"sup","set":"BFZ"}' -v
* Hostname was NOT found in DNS cache
*   Trying ::1...
* Connected to localhost (::1) port 8000 (#0)
> POST /drafts HTTP/1.1
> User-Agent: curl/7.37.1
> Host: localhost:8000
> Accept: */*
> Content-Length: 26
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 26 out of 26 bytes
< HTTP/1.1 201 Created
< Date: Fri, 13 Nov 2015 09:01:43 GMT
< Content-Length: 0
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
```

![localhost 8000 2015-11-13 01-02-13](https://cloud.githubusercontent.com/assets/116621/11142489/83a1affe-89a2-11e5-8c58-5024ae4dd687.png)

It should be considered that we might want to use something like `gorilla/mux` in the future so we can scope requests to http verbs like `POST`
